### PR TITLE
Add type form

### DIFF
--- a/app/assets/javascripts/welcome.coffee
+++ b/app/assets/javascripts/welcome.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the welcome controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,0 +1,4 @@
+class WelcomeController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/welcome_helper.rb
+++ b/app/helpers/welcome_helper.rb
@@ -1,0 +1,2 @@
+module WelcomeHelper
+end

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,0 +1,2 @@
+<div class="typeform-widget" data-url="https://ashleyhlivingston.typeform.com/to/E1dSoA" style="width: 100%; height: 500px;"></div>
+<script>(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm", b="https://embed.typeform.com/"; if(!gi.call(d,id)) { js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })() </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   resources :projects
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
+  get 'welcome', to: 'welcome#index'
+
   get 'volunteers/propose', to: 'volunteers#propose'
 
   resources :volunteers, except: [:index, :edit]

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class WelcomeControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
New `/welcome` endpoint created to display the type form created by @ahl389 that welcomes new members to the site so that slack invites and invites to join the codeforpdx organization on github can be sent out automatically.