### PR TITLE
Create rake task to automate meeting update

### DIFF
--- a/lib/tasks/meeting_scheduler.rake
+++ b/lib/tasks/meeting_scheduler.rake
@@ -1,0 +1,6 @@
+desc "Updates meeting startdate"
+task update_meeting: :environment do
+  m = Meeting.last
+  m.eventstart += 2.weeks
+  m.save
+end


### PR DESCRIPTION
Updates the eventstart date. This is being done so that heroku can run
the task bimonthly so that our event dates will be the correct date on
the website.