### PR TITLE
Only run rake task if meeting date is in the past

### DIFF
--- a/lib/tasks/meeting_scheduler.rake
+++ b/lib/tasks/meeting_scheduler.rake
@@ -1,6 +1,8 @@
 desc "Updates meeting startdate"
 task update_meeting: :environment do
-  m = Meeting.last
-  m.eventstart += 2.weeks
-  m.save
+  if Meeting.last.eventstart < Time.current
+    m = Meeting.last
+    m.eventstart += 2.weeks
+    m.save
+  end
 end


### PR DESCRIPTION
This is done because heroku scheduler cannot be set to run every two
weeks.